### PR TITLE
view all tags

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,7 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+        
         {
             "name": "Python: Request Handler",
             "type": "python",

--- a/json-server.py
+++ b/json-server.py
@@ -3,13 +3,26 @@ from http.server import HTTPServer
 from handler import HandleRequests, status
 
 from views import login_user, create_user
+from views import get_all_tags  # Import the function to fetch tags
 
 
 class JSONServer(HandleRequests):
 
     def do_GET(self):
-        pass
+        try:
+            url = self.parse_url(self.path)
 
+            if url["requested_resource"] == "tags":
+                tags = get_all_tags()
+                response = json.dumps(tags)
+                self.response(response, status.HTTP_200_SUCCESS.value)
+            else:
+                self.response(json.dumps({"error": "Resource not found"}), status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value)
+
+        except Exception as e:
+            print(f"Error processing GET request: {str(e)}")
+            self.response(json.dumps({"error": "Internal server error"}), status.HTTP_500_SERVER_ERROR.value)
+            
     def do_POST(self):
         try:
             url = self.parse_url(self.path)

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,1 +1,2 @@
 from .user import login_user, create_user
+from .tags import get_all_tags  # Assuming the function is in tag.py

--- a/views/tags.py
+++ b/views/tags.py
@@ -1,0 +1,13 @@
+import sqlite3
+
+def get_all_tags():
+    conn = sqlite3.connect('./db.sqlite3')
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT label FROM Tags ORDER BY label ASC")
+    tags = cursor.fetchall()
+
+    conn.close()
+
+    # Convert the list of tuples to a list of strings
+    return [tag[0] for tag in tags]


### PR DESCRIPTION
This pull request implements a new feature that allows users (currently, all users are treated as admin users) to retrieve a list of all available tags in the system, ordered alphabetically. The feature is part of the Tag Management functionality, which will be further developed to include editing and deleting tags.

Key Changes:
json-server.py:

Added a new route in the do_GET method to handle requests for the /tags endpoint.
This route calls the get_all_tags function, which retrieves the list of tags from the database.
views/tag.py:

Created a new function, get_all_tags, which connects to the SQLite database and fetches all tags, ordered alphabetically by their label.
The function returns a list of tag labels.
handler.py:

No changes in this file, but utilized the existing HandleRequests class for parsing URLs and responding to HTTP requests.
loaddata.sql:

Added SQL commands to insert initial data into the Tags table for testing purposes.
How to Test:
Run the server using json-server.py.
Navigate to http://localhost:8088/tags in your browser or use a tool like Postman to send a GET request.
You should receive a JSON response containing a list of all tags in the database, sorted alphabetically.