### PR TITLE
Feature/delete category api

### DIFF
--- a/json-server.py
+++ b/json-server.py
@@ -91,7 +91,26 @@ class JSONServer(HandleRequests):
             )
 
     def do_DELETE(self):
-        pass
+        try:
+            url = self.parse_url(self.path)
+            
+            if url["requested_resource"] == "categories":
+                if url["pk"]:
+                    category_id = url["pk"]
+                    delete_success = delete_category(category_id)  # Implement this function in your views
+
+                    if delete_success:
+                        self.response("", status.HTTP_204_SUCCESS_NO_RESPONSE_BODY.value)
+                    else:
+                        self.response(json.dumps({"error": "Failed to delete category"}), status.HTTP_500_SERVER_ERROR.value)
+                else:
+                    self.response(json.dumps({"error": "Resource not found"}), status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value)
+            else:
+                self.response(json.dumps({"error": "Resource not found"}), status.HTTP_404_CLIENT_ERROR_RESOURCE_NOT_FOUND.value)
+
+        except Exception as e:
+            print(f"Error processing DELETE request: {str(e)}")
+            self.response(json.dumps({"error": "Internal server error"}), status.HTTP_500_SERVER_ERROR.value)
 
     def do_PUT(self):
         try:

--- a/json-server.py
+++ b/json-server.py
@@ -7,6 +7,7 @@ from views import get_all_tags  # Import the function to fetch tags
 from views import get_categories, update_category
 from views import get_posts
 from views import update_tag, get_tag_by_id  # Import the necessary functions
+from views import delete_category
 
 
 class JSONServer(HandleRequests):
@@ -93,11 +94,11 @@ class JSONServer(HandleRequests):
     def do_DELETE(self):
         try:
             url = self.parse_url(self.path)
-            
+
             if url["requested_resource"] == "categories":
                 if url["pk"]:
                     category_id = url["pk"]
-                    delete_success = delete_category(category_id)  # Implement this function in your views
+                    delete_success = delete_category(category_id)  # Implemented in views/categories.py
 
                     if delete_success:
                         self.response("", status.HTTP_204_SUCCESS_NO_RESPONSE_BODY.value)
@@ -111,7 +112,7 @@ class JSONServer(HandleRequests):
         except Exception as e:
             print(f"Error processing DELETE request: {str(e)}")
             self.response(json.dumps({"error": "Internal server error"}), status.HTTP_500_SERVER_ERROR.value)
-
+            
     def do_PUT(self):
         try:
             url = self.parse_url(self.path)

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,4 +1,4 @@
 from .user import login_user, create_user
 from .tags import get_all_tags, edit_tag_view, get_tag_by_id, update_tag
-from .categories import get_categories, update_category
+from .categories import get_categories, update_category, delete_category
 from .posts import get_posts

--- a/views/categories.py
+++ b/views/categories.py
@@ -35,6 +35,7 @@ def update_category(category_id, new_data):
         return False
 
 def delete_category(category_id):
+    """Delete a category from the database."""
     try:
         with sqlite3.connect("./db.sqlite3") as conn:
             db_cursor = conn.cursor()

--- a/views/categories.py
+++ b/views/categories.py
@@ -33,3 +33,20 @@ def update_category(category_id, new_data):
     except Exception as e:
         print(f"Error updating category: {str(e)}")
         return False
+
+def delete_category(category_id):
+    try:
+        with sqlite3.connect("./db.sqlite3") as conn:
+            db_cursor = conn.cursor()
+            db_cursor.execute(
+                """
+                DELETE FROM Categories
+                WHERE id = ?
+                """,
+                (category_id,)
+            )
+            conn.commit()
+            return db_cursor.rowcount > 0  # Return True if the deletion was successful
+    except Exception as e:
+        print(f"Error deleting category: {str(e)}")
+        return False


### PR DESCRIPTION
Description

This introduces functionality to delete categories on the server. Changes made:

	•	Added a delete_category function to categories.py to handle category deletion from the database.
	•	Updated json-server.py to include the do_DELETE method, which processes DELETE requests for categories.
	•	Integrated the DELETE functionality with error handling for cases where the category is not found or the deletion fails.

Testing

The following tests have been performed:

	•	Verified GET and DELETE then GET requests for /categories/ using Postman.
	•	Confirmed that the DELETE functionality correctly removes categories from the database and handles errors appropriately.
